### PR TITLE
Added ClipRect to person_details.dart

### DIFF
--- a/lib/screens/common/person_details.dart
+++ b/lib/screens/common/person_details.dart
@@ -53,7 +53,8 @@ class PersonDetails extends StatelessWidget {
                       width: 4.0,
                     ),
                   ),
-                  child: ClipOval(
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(180),
                     child: networkImageUrl != null
                         ? CachedNetworkImage(
                             fit: BoxFit.cover,


### PR DESCRIPTION
This should solve the IOS rendering issue in safari for profile images. Currently when viewing on a mobile device or computer with safari the profile images render as squares.